### PR TITLE
Fix TypeError in pqk data_map_func with unbound ParameterExpression (Qiskit 2.2.0)

### DIFF
--- a/qbiocode/embeddings/embed.py
+++ b/qbiocode/embeddings/embed.py
@@ -66,7 +66,13 @@ def pqk(
                 float: the mapped value
             """
             coeff = x[0] / 2 if len(x) == 1 else reduce(lambda m, n: (m * n) / 2, x)
-            return float(coeff)
+            try:
+                return float(coeff)
+            except TypeError:
+                # coeff is a symbolic ParameterExpression during circuit
+                # construction (unbound parameters) — return it unevaluated
+                # and let Qiskit bind real values later.
+                return coeff
 
     else:
         data_map_func = None


### PR DESCRIPTION
## Problem

Running `pqk()` in `qbiocode/embeddings/embed.py` raises:

    TypeError: Parameter expression with unbound parameters {Symbol { name: "_", ... }} is not numeric.

This fires during quantum circuit construction — specifically in `circuit.compose(feature_map, inplace=True)`,
which triggers `PauliFeatureMap`'s lazy `_build()`, which in turn calls the user-supplied `data_map_func`
with symbolic (unbound) `ParameterExpression` objects rather than concrete numeric values.

## Root cause

Qiskit's documented signature for `data_map_func` is `Callable[[Parameter], ParameterExpression]`
(see [zz_feature_map docs](https://quantum.cloud.ibm.com/docs/en/api/qiskit/qiskit.circuit.library.zz_feature_map)) —
i.e. it's expected to handle symbolic parameters, not only bound numeric data. In current Qiskit
(tested on 2.2.0), this function is invoked during circuit *construction*, before any real data is bound,
so `x` contains `ParameterExpression` objects. The existing `float(coeff)` call assumes `coeff` is always
a plain number, which breaks under this calling convention.

## Fix

Wrap the numeric cast in a `try/except TypeError`. When `coeff` is a concrete number, behavior is unchanged
(`float(coeff)` succeeds as before). When `coeff` is a symbolic, unbound `ParameterExpression`, return it
unevaluated so Qiskit can bind real values later during circuit execution.

## To reproduce (pre-fix)

Run the PQK cell in the QSage tutorial notebook (`tutorial/QSage/qsage.ipynb`) with `qiskit==2.2.0` —
fails at `circuit.compose(feature_map, inplace=True)` inside `pqk()`.

## Testing done

Ran the PQK workflow end-to-end post-fix, including live execution against real IBM Quantum hardware
(`ibm_fez`), with no regressions observed in the numeric-input path.

Found while working through the ISMB 2026 tutorial materials.